### PR TITLE
implementada compatibilidade com django-crispy-forms e  django-bootstrap3

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,0 +1,19 @@
+=======
+Credits
+=======
+
+Development Lead
+----------------
+
+* Caio Ariede (`@caioariede`_)
+
+Contributors
+------------
+
+* Paulo Nunes - paulo dot botta at hotmail dot com
+* Fabio Caritas Barrionuevo da Luz (`@luzfcb`_)
+
+
+.. _`@caioariede`: https://github.com/caioariede
+.. _`@luzfcb`: https://github.com/luzfcb
+

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,0 +1,20 @@
+.. :changelog:
+
+History
+-------
+
+1.3.8 (2013-11-20)
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+New features:
+
+* Added compatibility with django-crispy-forms and django-bootstrap3, thanks to `@luzfcb`_ and Paulo Nunes - paulo dot botta at hotmail dot com
+
+
+Bug fixes:
+
+* Partial resolution of issue #4, thanks to `@luzfcb`_ and Paulo Nunes - paulo dot botta at hotmail dot com
+
+.. _`@luzfcb`: https://github.com/luzfcb
+
+

--- a/input_mask/widgets.py
+++ b/input_mask/widgets.py
@@ -29,12 +29,14 @@ class InputMask(forms.TextInput):
             else:
                 class_ = 'mask mask-reverse '
 
-            class_ += dumps(self.mask).replace('"', '&quot;')
+            #class_ += dumps(self.mask).replace('"', '&quot;')
+            class_ += dumps(self.mask).replace("'", '&quot;')
 
-            if attrs is not None and 'class' in attrs:
-                class_ = '%s %s' % (attrs['class'], class_)
-
-            attrs['class'] = mark_safe(class_)
+            final_attrs = self.build_attrs(self.attrs, type=self.input_type, name=name)
+            if 'class' in final_attrs:
+                attrs['class'] = u'%s %s' % (final_attrs['class'], mark_safe(class_))
+            else:
+                attrs['class'] = mark_safe(class_)
 
         return super(InputMask, self).render(name, value, attrs=attrs)
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from distutils.core import setup
 from distutils.sysconfig import get_python_lib
 
 
-VERSION = '1.3.7'
+VERSION = '1.3.8'
 
 # Warn if we are installing over top of an existing installation. This can
 # cause issues where files that were deleted from a more recent Django are


### PR DESCRIPTION
O django-input-mask utiliza o campo ```class``` da tag input html, para definir a mascara.

O django-crispy-forms e o django-bootstrap3 utilizam o campo ```class``` da tag input html, para definir a classe CSS a ser utilizada para aquele campo.

Problema:

O django-input-mask substitui totalmente o campo ```class``` gerado pelo django-crispy-forms e o django-bootstrap3

Solução: 

Adicionado compatibilidade com django-crispy-forms e  django-bootstrap3, que tambem soluciona parcialmente o issue #4 