### PR TITLE
zip_safe=False to force not create zip Archive

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
     author_email='caio.ariede@gmail.com',
     description='JavaScript input masks for Django',
     license='MIT',
+    zip_safe=False,
     platforms=['any'],
     packages=find_packages(),
     package_data={'input_mask': [


### PR DESCRIPTION
The zip_safe flag can be used to force or prevent zip Archive creation (.egg). In general you probably don’t want your packages to be installed as zip files because some tools do not support them and they make debugging a lot harder.